### PR TITLE
Remove in-source TODOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ This README only contains a brief overview of the library's current contents. Al
 
 Utilizing Chisel and ChiselSim, `approx` requires a suitable installation of Scala. For this purpose, we use the Scala Build Tool (`sbt`) for which we provide a suitable build script. The provided tests require a recent version of Verilator.
 
-This library is tested in Ubuntu 24.04 with Verilator 5.032. Note that the default Verilator version (5.020) available through `apt` in Ubunty 24.04 is _not_ new enough.
+This library is tested in Ubuntu 24.04 with Verilator 5.032. Note that the default Verilator version (5.020) available through `apt` in Ubunty 24.04 is _not_ new enough. If you wish to have VCD dumps from the simulations, pass the `emitVcd` flag to `testOnly`, for example:
+
+```bash
+sbt "testOnly approx.addition.RCASpec -- -DemitVcd=1"
+```
 
 ***
 # Adders

--- a/src/main/scala/approx/accumulation/Exact.scala
+++ b/src/main/scala/approx/accumulation/Exact.scala
@@ -1,8 +1,10 @@
 package approx.accumulation
 
 import chisel3._
+import chisel3.util.RegEnable
 import chisel3.util.experimental.FlattenInstance
 
+import approx.util.PRShiftReg
 import approx.multiplication.comptree.{Approximation, Signature, CompressorTree}
 
 /** Simple accumulator
@@ -10,16 +12,32 @@ import approx.multiplication.comptree.{Approximation, Signature, CompressorTree}
  * @param inW the width of the input operand
  * @param accW the width of the accumulator
  * @param signed whether the input operands are signed (defaults to false)
+ * @param pipes the number of pipeline stages (defaults to 0)
+ * 
+ * Pipelining relies on retiming!
  */
-class SimpleAccumulator(inW: Int, accW: Int, signed: Boolean = false) extends SA(inW, accW, signed) {
+class SimpleAccumulator(inW: Int, accW: Int, signed: Boolean = false, pipes: Int = 0)
+  extends SA(inW, accW, signed, pipes) {
   // Extend the input to the width of the accumulator if needed
   val inExt = if (inW < accW) {
     val sext = if (signed) VecInit(Seq.fill(accW - inW)(io.in(inW-1))).asUInt else 0.U((accW - inW).W)
     sext ## io.in
   } else io.in(accW-1, 0)
 
-  val acc = RegInit(0.U(accW.W))
-  acc := inExt + Mux(io.zero, 0.U, acc)
+  // Pass the extended input through a series of registers
+  val dataShReg = Module(new PRShiftReg(UInt(accW.W), pipes))
+  dataShReg.io.in := inExt
+
+  // Pass enable and zero through a shift register as needed
+  val enShReg = Module(new PRShiftReg(Bool(), pipes))
+  enShReg.io.in := io.en
+  val zeroShReg = Module(new PRShiftReg(Bool(), pipes))
+  zeroShReg.io.in := io.zero
+
+  // Compute the sum and register the accumulator
+  val sum = Wire(UInt(accW.W))
+  val acc = RegEnable(sum, 0.U(accW.W), enShReg.io.out.last)
+  sum    := dataShReg.io.out.last + Mux(zeroShReg.io.out.last, 0.U, acc)
   io.acc := acc
 }
 
@@ -29,10 +47,12 @@ class SimpleAccumulator(inW: Int, accW: Int, signed: Boolean = false) extends SA
  * @param inBW the width of the second input operand
  * @param accW the width of the accumulator
  * @param signed whether the input operands are signed (defaults to false)
+ * @param pipes the number of pipeline stages (defaults to 0)
  * 
- * @todo Extend with different signs.
+ * Pipelining relies on retiming!
  */
-class MultiplyAccumulator(inAW: Int, inBW: Int, accW: Int, signed: Boolean = false) extends MAC(inAW, inBW, accW, signed) {
+class MultiplyAccumulator(inAW: Int, inBW: Int, accW: Int, signed: Boolean = false, pipes: Int = 0)
+  extends MAC(inAW, inBW, accW, signed, pipes) {
   // Compute and extend the product to the width of the accumulator if needed
   val prodExt = if ((inAW + inBW) < accW) {
     val prod = if (signed) (io.a.asSInt * io.b.asSInt).asUInt else io.a * io.b
@@ -42,8 +62,20 @@ class MultiplyAccumulator(inAW: Int, inBW: Int, accW: Int, signed: Boolean = fal
     (if (signed) (io.a.asSInt * io.b.asSInt) else (io.a * io.b))(accW-1, 0)
   }
 
-  val acc = RegInit(0.U(accW.W))
-  acc := prodExt + Mux(io.zero, 0.U, acc)
+  // Pass the extended product through a series of registers
+  val dataShReg = Module(new PRShiftReg(UInt(accW.W), pipes))
+  dataShReg.io.in := prodExt
+
+  // Pass enable and zero through a shift register as needed
+  val enShReg = Module(new PRShiftReg(Bool(), pipes))
+  enShReg.io.in := io.en
+  val zeroShReg = Module(new PRShiftReg(Bool(), pipes))
+  zeroShReg.io.in := io.zero
+
+  // Compute the sum and register the accumulator
+  val sum = Wire(UInt(accW.W))
+  val acc = RegEnable(sum, 0.U(accW.W), enShReg.io.out.last)
+  sum := dataShReg.io.out.last + Mux(zeroShReg.io.out.last, 0.U, acc)
   io.acc := acc
 }
 
@@ -51,16 +83,19 @@ class MultiplyAccumulator(inAW: Int, inBW: Int, accW: Int, signed: Boolean = fal
  * 
  * @param sig the input bit matrix' signature
  * @param accW the width of the accumulator
+ * @param pipes the number of pipeline stages (defaults to 0)
  * @param targetDevice a string indicating the target device
  *                     (defaults to "", meaning ASIC)
  * @param mtrc which metric to use for selecting counters (defaults to efficiency)
  * @param approx the targeted approximation styles (defaults to no approximation)
+ * 
+ * Pipelining relies on retiming!
+ * 
+ * @todo Consider building pipelining into the compressor tree generator.
  */
-class BitMatrixAccumulator(sig: Signature, accW: Int, targetDevice: String = "",
+class BitMatrixAccumulator(sig: Signature, accW: Int, pipes: Int = 0, targetDevice: String = "",
   mtrc: Char = 'e', approx: Seq[Approximation] = Seq.empty[Approximation])
-  extends MxAC(sig, accW) with FlattenInstance {
-  val acc = RegInit(0.U(accW.W))
-
+  extends MxAC(sig, accW, pipes) with FlattenInstance {
   // Add the accumulator to the input signature
   val sigExt = new Signature((0 until scala.math.max(accW, sig.length)).map { c =>
     val sigCnt = if (c < sig.length) sig.signature(c) else 0
@@ -69,7 +104,8 @@ class BitMatrixAccumulator(sig: Signature, accW: Int, targetDevice: String = "",
   }.toArray)
 
   // Build a compressor tree and assign its inputs and outputs
-  val comp = Module(CompressorTree(sigExt, targetDevice=targetDevice, mtrc=mtrc, approx=approx))
+  val acc     = Wire(UInt(accW.W))
+  val comp    = Module(CompressorTree(sigExt, targetDevice=targetDevice, mtrc=mtrc, approx=approx))
   val compIns = Wire(Vec(sigExt.count, Bool()))
   var (inOffset, compOffset) = (0, 0)
   (0 until scala.math.max(accW, sig.length)).foreach { c =>
@@ -89,9 +125,19 @@ class BitMatrixAccumulator(sig: Signature, accW: Int, targetDevice: String = "",
     }
   }
 
+  // Pass the compressor output through a series of registers
+  val dataShReg = Module(new PRShiftReg(UInt(accW.W), pipes))
   comp.io.in := compIns.asUInt
-  acc := comp.io.out
-  io.acc := acc
+  dataShReg.io.in := comp.io.out
+
+  // Pass enable through a shift register as needed
+  val enShReg = Module(new PRShiftReg(Bool(), pipes))
+  enShReg.io.in := io.en
+
+  // Compute the sum and register the accumulator
+  val accReg = RegEnable(comp.io.out, 0.U(accW.W), enShReg.io.out.last)
+  acc    := accReg
+  io.acc := accReg
 }
 
 /** Parallel simple accumulator
@@ -100,15 +146,19 @@ class BitMatrixAccumulator(sig: Signature, accW: Int, targetDevice: String = "",
  * @param inW the width of the input operands
  * @param accW the width of the accumulator
  * @param signed whether the input operands are signed (defaults to false)
+ * @param pipes the number of pipeline stages (defaults to 0)
  * @param comp whether to use the compressor tree generator (defaults to false)
  * @param targetDevice a string indicating the target device
  *                     (defaults to "", meaning ASIC)
  * @param mtrc which metric to use for selecting counters (defaults to efficiency)
  * @param approx the targeted approximation styles (defaults to no approximation)
+ * 
+ * Pipelining relies on retiming!
  */
 class ParallelSimpleAccumulator(nIn: Int, inW: Int, accW: Int, signed: Boolean = false,
-  comp: Boolean = false, targetDevice: String = "", mtrc: Char = 'e', approx: Seq[Approximation] = Seq.empty[Approximation])
-  extends PSA(nIn, inW, accW, signed) with FlattenInstance {
+  pipes: Int = 0, comp: Boolean = false, targetDevice: String = "", mtrc: Char = 'e',
+  approx: Seq[Approximation] = Seq.empty[Approximation])
+  extends PSA(nIn, inW, accW, signed, pipes) with FlattenInstance {
   // Extend the inputs to the width of the accumulator if needed
   val insExt = if (inW < accW) {
     if (signed) {
@@ -124,18 +174,28 @@ class ParallelSimpleAccumulator(nIn: Int, inW: Int, accW: Int, signed: Boolean =
     val sig  = new Signature(Array.fill(extW)(nIn))
 
     // Build a bit matrix accumulator and assign its inputs and outputs
-    val mxAcc  = Module(new BitMatrixAccumulator(sig, accW, targetDevice, mtrc, approx))
+    val mxAcc  = Module(new BitMatrixAccumulator(sig, accW, pipes, targetDevice, mtrc, approx))
     val accIns = VecInit((0 until extW).flatMap { c => (0 until nIn).map(i => insExt(i)(c)) }).asUInt
 
+    mxAcc.io.en   := io.en
     mxAcc.io.zero := io.zero
     mxAcc.io.in   := accIns
     io.acc := mxAcc.io.acc
   } else {
-    // Instantiate an accumulator register
-    val acc = RegInit(0.U(accW.W))
+    // Pass the parallel sum through a series of registers
+    val dataShReg = Module(new PRShiftReg(UInt(accW.W), pipes))
+    dataShReg.io.in := insExt.reduceTree(_ +& _)
 
-    // Connect and sum the extended inputs
-    acc := insExt.reduceTree(_ +& _) + Mux(io.zero, 0.U, acc)
+    // Pass enable and zero through a shift register as needed
+    val enShReg = Module(new PRShiftReg(Bool(), pipes))
+    enShReg.io.in := io.en
+    val zeroShReg = Module(new PRShiftReg(Bool(), pipes))
+    zeroShReg.io.in := io.zero
+
+    // Compute the sum and register the accumulator
+    val sum = Wire(UInt(accW.W))
+    val acc = RegEnable(sum, 0.U(accW.W), enShReg.io.out.last)
+    sum    := dataShReg.io.out.last + Mux(zeroShReg.io.out.last, 0.U, acc)
     io.acc := acc
   }
 }
@@ -147,17 +207,19 @@ class ParallelSimpleAccumulator(nIn: Int, inW: Int, accW: Int, signed: Boolean =
  * @param inBW the width of the second input operands
  * @param accW the width of the accumulator
  * @param signed whether the input operands are signed (defaults to false)
+ * @param pipes the number of pipeline stages (defaults to 0)
  * @param comp whether to use the compressor tree generator (defaults to false)
  * @param targetDevice a string indicating the target device
  *                     (defaults to "", meaning ASIC)
  * @param mtrc which metric to use for selecting counters (defaults to efficiency)
  * @param approx the targeted approximation styles (defaults to no approximation)
  * 
- * @todo Extend with different signs.
+ * Pipelining relies on retiming!
  */
 class ParallelMultiplyAccumulator(nIn: Int, inAW: Int, inBW: Int, accW: Int, signed: Boolean = false,
-  comp: Boolean = false, targetDevice: String = "", mtrc: Char = 'e', approx: Seq[Approximation] = Seq.empty[Approximation])
-  extends PMAC(nIn, inAW, inBW, accW, signed) with FlattenInstance {
+  pipes: Int = 0, comp: Boolean = false, targetDevice: String = "", mtrc: Char = 'e',
+  approx: Seq[Approximation] = Seq.empty[Approximation])
+  extends PMAC(nIn, inAW, inBW, accW, signed, pipes) with FlattenInstance {
 
   // Depending on the parameters passed, generate a naive accumulator or use 
   // the custom compressor tree generator
@@ -215,7 +277,7 @@ class ParallelMultiplyAccumulator(nIn: Int, inAW: Int, inBW: Int, accW: Int, sig
     }
 
     // Build a bit matrix accumulator and assign its inputs and outputs
-    val mxAcc  = Module(new BitMatrixAccumulator(sig, accW, targetDevice, mtrc, approx))
+    val mxAcc  = Module(new BitMatrixAccumulator(sig, accW, pipes, targetDevice, mtrc, approx))
     val accIns = Wire(Vec(sig.count, Bool()))
     var compOffset = 0
     (0 until sig.length).foreach { c =>
@@ -236,6 +298,7 @@ class ParallelMultiplyAccumulator(nIn: Int, inAW: Int, inBW: Int, accW: Int, sig
       }
     }
 
+    mxAcc.io.en   := io.en
     mxAcc.io.zero := io.zero
     mxAcc.io.in   := accIns.asUInt
     io.acc := mxAcc.io.acc
@@ -253,11 +316,20 @@ class ParallelMultiplyAccumulator(nIn: Int, inAW: Int, inBW: Int, accW: Int, sig
       })
     }
 
-    // Instantiate an accumulator register
-    val acc = RegInit(0.U(accW.W))
+    // Pass the parallel sum through a series of registers
+    val dataShReg = Module(new PRShiftReg(UInt(accW.W), pipes))
+    dataShReg.io.in := prodsExt.reduceTree(_ +& _)
+
+    // Pass enable and zero through a shift register as needed
+    val enShReg = Module(new PRShiftReg(Bool(), pipes))
+    enShReg.io.in := io.en
+    val zeroShReg = Module(new PRShiftReg(Bool(), pipes))
+    zeroShReg.io.in := io.zero
 
     // Connect and sum the extended products
-    acc := prodsExt.reduceTree(_ +& _) + Mux(io.zero, 0.U, acc)
+    val sum = Wire(UInt(accW.W))
+    val acc = RegEnable(sum, 0.U(accW.W), enShReg.io.out.last)
+    sum    := dataShReg.io.out.last + Mux(zeroShReg.io.out.last, 0.U, acc)
     io.acc := acc
   }
 }

--- a/src/main/scala/approx/accumulation/package.scala
+++ b/src/main/scala/approx/accumulation/package.scala
@@ -28,12 +28,13 @@ package object accumulation {
 
   /** Multiply accumulator IO bundle
    * 
-   * @param inW the width of the input operands
+   * @param inAW the width of the first input operand
+   * @param inBW the width of the second input operand
    * @param accW the width of the accumulator
    */
-  class MultiplyAccumulatorIO(inW: Int, accW: Int) extends AccumulatorIO(accW) {
-    val a = Input(UInt(inW.W))
-    val b = Input(UInt(inW.W))
+  class MultiplyAccumulatorIO(inAW: Int, inBW: Int, accW: Int) extends AccumulatorIO(accW) {
+    val a = Input(UInt(inAW.W))
+    val b = Input(UInt(inBW.W))
   }
 
   /** Bit matrix accumulator IO bundle
@@ -58,12 +59,13 @@ package object accumulation {
   /** Parallel multiply accumulator IO bundle
    * 
    * @param nIn the number of parallel input operands
-   * @param inW the width of the input operands
+   * @param inAW the width of the first input operands
+   * @param inBW the width of the second input operands
    * @param accW the width of the accumulator
    */
-  class ParallelMultiplyAccumulatorIO(nIn: Int, inW: Int, accW: Int) extends AccumulatorIO(accW) {
-    val as = Input(Vec(nIn, UInt(inW.W)))
-    val bs = Input(Vec(nIn, UInt(inW.W)))
+  class ParallelMultiplyAccumulatorIO(nIn: Int, inAW: Int, inBW: Int, accW: Int) extends AccumulatorIO(accW) {
+    val as = Input(Vec(nIn, UInt(inAW.W)))
+    val bs = Input(Vec(nIn, UInt(inBW.W)))
   }
 
   /** Abstract simple accumulator module class
@@ -78,14 +80,15 @@ package object accumulation {
 
   /** Abstract multiply accumulator module class
    * 
-   * @param inW the width of the input operands
+   * @param inAW the width of the first input operand
+   * @param inBW the width of the second input operand
    * @param accW the width of the accumulator
    * @param signed whether input operands are signed
    * 
-   * @todo Extend with different operand widths and different signs.
+   * @todo Extend with different signs.
    */
-  abstract class MAC(val inW: Int, val accW: Int, val signed: Boolean) extends Module {
-    val io = IO(new MultiplyAccumulatorIO(inW, accW))
+  abstract class MAC(val inAW: Int, val inBW: Int, val accW: Int, val signed: Boolean) extends Module {
+    val io = IO(new MultiplyAccumulatorIO(inAW, inBW, accW))
   }
 
   /** Abstract bit matrix accumulator module class
@@ -111,13 +114,14 @@ package object accumulation {
   /** Parallel multiply accumulator module class
    * 
    * @param nIn the number of parallel input operands
-   * @param inW the width of the input operands
+   * @param inAW the width of the first input operands
+   * @param inBW the width of the second input operands
    * @param accW the width of the accumulator
    * @param signed whether the input operands are signed
    * 
-   * @todo Extend with different operand widths and different signs.
+   * @todo Extend with different signs.
    */
-  abstract class PMAC(val nIn: Int, val inW: Int, val accW: Int, val signed: Boolean) extends Module {
-    val io = IO(new ParallelMultiplyAccumulatorIO(nIn, inW, accW))
+  abstract class PMAC(val nIn: Int, val inAW: Int, val inBW: Int, val accW: Int, val signed: Boolean) extends Module {
+    val io = IO(new ParallelMultiplyAccumulatorIO(nIn, inAW, inBW, accW))
   }
 }

--- a/src/main/scala/approx/accumulation/package.scala
+++ b/src/main/scala/approx/accumulation/package.scala
@@ -5,14 +5,16 @@ import chisel3._
 import approx.multiplication.comptree.Signature
 
 package object accumulation {
-  
-  /** @todo Extend all these with support for pipelining! */
 
   /** Accumulator IO bundle
    * 
    * @param accW the width of the accumulator
+   * 
+   * Asserting `en` enables accumulation of the input operand(s) into the
+   * accumulator. Asserting `zero` resets the accumulator to zero.
    */
   private[accumulation] abstract class AccumulatorIO(accW: Int) extends Bundle {
+    val en   = Input(Bool())
     val zero = Input(Bool())
     val acc  = Output(UInt(accW.W))
   }
@@ -73,8 +75,9 @@ package object accumulation {
    * @param inW the width of the input operand
    * @param accW the width of the accumulator
    * @param signed whether input operands are signed
+   * @param pipes the number of pipeline stages
    */
-  abstract class SA(val inW: Int, val accW: Int, val signed: Boolean) extends Module {
+  abstract class SA(val inW: Int, val accW: Int, val signed: Boolean, val pipes: Int) extends Module {
     val io = IO(new SimpleAccumulatorIO(inW, accW))
   }
 
@@ -84,10 +87,9 @@ package object accumulation {
    * @param inBW the width of the second input operand
    * @param accW the width of the accumulator
    * @param signed whether input operands are signed
-   * 
-   * @todo Extend with different signs.
+   * @param pipes the number of pipeline stages
    */
-  abstract class MAC(val inAW: Int, val inBW: Int, val accW: Int, val signed: Boolean) extends Module {
+  abstract class MAC(val inAW: Int, val inBW: Int, val accW: Int, val signed: Boolean, val pipes: Int) extends Module {
     val io = IO(new MultiplyAccumulatorIO(inAW, inBW, accW))
   }
 
@@ -95,8 +97,9 @@ package object accumulation {
    * 
    * @param sig the input bit matrix' signature
    * @param accW the width of the accumulator
+   * @param pipes the number of pipeline stages
    */
-  abstract class MxAC(val sig: Signature, val accW: Int) extends Module {
+  abstract class MxAC(val sig: Signature, val accW: Int, val pipes: Int) extends Module {
     val io = IO(new MatrixAccumulatorIO(sig, accW))
   }
 
@@ -106,8 +109,9 @@ package object accumulation {
    * @param inW the width of the input operands
    * @param accW the width of the accumulator
    * @param signed whether the input operands are signed
+   * @param pipes the number of pipeline stages
    */
-  abstract class PSA(val nIn: Int, val inW: Int, val accW: Int, val signed: Boolean) extends Module {
+  abstract class PSA(val nIn: Int, val inW: Int, val accW: Int, val signed: Boolean, val pipes: Int) extends Module {
     val io = IO(new ParallelSimpleAccumulatorIO(nIn, inW, accW))
   }
 
@@ -118,10 +122,9 @@ package object accumulation {
    * @param inBW the width of the second input operands
    * @param accW the width of the accumulator
    * @param signed whether the input operands are signed
-   * 
-   * @todo Extend with different signs.
+   * @param pipes the number of pipeline stages
    */
-  abstract class PMAC(val nIn: Int, val inAW: Int, val inBW: Int, val accW: Int, val signed: Boolean) extends Module {
+  abstract class PMAC(val nIn: Int, val inAW: Int, val inBW: Int, val accW: Int, val signed: Boolean, val pipes: Int) extends Module {
     val io = IO(new ParallelMultiplyAccumulatorIO(nIn, inAW, inBW, accW))
   }
 }

--- a/src/main/scala/approx/addition/Exact.scala
+++ b/src/main/scala/approx/addition/Exact.scala
@@ -217,8 +217,6 @@ class CSA(width: Int, val stages: Int) extends Adder(width) {
 /** Exact parallel prefix adder base class
  * 
  * @param width the width of the adder
- * 
- * @todo Remove redundant extension bits in this design.
  */
 abstract class PPA(width: Int) extends Adder(width) {
   /** Bundle of generate and propagate bits */

--- a/src/main/scala/approx/multiplication/comptree/TerminalAdders.scala
+++ b/src/main/scala/approx/multiplication/comptree/TerminalAdders.scala
@@ -1,0 +1,188 @@
+package approx.multiplication.comptree
+
+import chisel3._
+import chisel3.util._
+
+import approx.util.Xilinx.Common.{genLUT6_2InitString, LUT6_2}
+import approx.util.Xilinx.SevenSeries.CARRY4
+import approx.util.Xilinx.Versal.{genLUT6CYInitString, LOOKAHEAD8, LUT6CY}
+
+/** Collection of terminal adders useful for compressor tree
+ * generation for different devices. We currently include the
+ * following device types:
+ * - Xilinx FPGAs (denoted by `Xilinx.{SevenSeries, Versal}`)
+ */
+private[comptree] object TerminalAdders {
+  /** Abstract terminal adder class
+   * 
+   * @param inOps number of input operands
+   * @param outW  in-/output bit width
+   */
+  private[TerminalAdders] abstract class TerminalAdder(inOps: Int, outW: Int) extends Module {
+    val io = IO(new Bundle {
+      val in  = Input(Vec(inOps, UInt(outW.W)))
+      val out = Output(UInt(outW.W))
+    })
+  }
+
+  /** Ternary adder for Xilinx 7-Series and UltraScale FPGAs
+   * 
+   * @param outW in-/output bit width
+   * 
+   * Implements a ternary adder using LUT6_2 and CARRY4 primitives.
+   * The adder takes three input operands of equal bit width and
+   * produces a single output sum of the same bit width.
+   * 
+   * Note, does not implement any form of carry-in.
+   */
+  class TernaryAdder(outW: Int) extends TerminalAdder(3, outW) {
+    // Boolean functions for the LUTs
+    val lutFO5 = (ins: Seq[Boolean]) => (ins(1) && ins(2)) || (ins(1) && ins(3)) || (ins(2) && ins(3))
+    val lutFO6 = (ins: Seq[Boolean]) => ins.take(4).reduce(_ ^ _)
+
+    // Generate CARRY4 elements
+    val nCarry4 = (outW + 3) / 4
+    val carries = Seq.fill(nCarry4) { Module(new CARRY4) }
+    carries.head.io.CI     := false.B
+    carries.head.io.CYINIT := false.B
+    (1 until nCarry4).foreach { i =>
+      carries(i).io.CI     := carries(i-1).io.CO(3)
+      carries(i).io.CYINIT := false.B
+    }
+
+    // Generate LUT6_2 elements and connect to CARRY4s
+    val tPrimes = Wire(Vec(outW+1, Bool()))
+    val luts    = Seq.fill(outW) { Module(new LUT6_2(genLUT6_2InitString(lutFO5, lutFO6))) }
+    tPrimes(0) := false.B
+    (0 until outW).foreach { i =>
+      luts(i).io.I0 := io.in(0)(i)
+      luts(i).io.I1 := io.in(1)(i)
+      luts(i).io.I2 := io.in(2)(i)
+      luts(i).io.I3 := tPrimes(i)
+      luts(i).io.I4 := false.B
+      luts(i).io.I5 := false.B
+
+      // Connect to CARRY4
+      tPrimes(i+1) := luts(i).io.O5
+    }
+    carries.zipWithIndex.foreach {
+      case (carry4, idx) if idx == nCarry4 - 1 && outW % 4 != 0 => // last CARRY4, not fully used
+        val usedBits = outW % 4
+        carry4.io.S  := VecInit(luts.drop(idx * 4).map(_.io.O6) ++ Seq.fill(4 - usedBits)(false.B)).asUInt
+        carry4.io.DI := VecInit(tPrimes.drop(idx * 4) ++ Seq.fill(4 - usedBits)(false.B)).asUInt
+      case (carry4, idx) => // fully used CARRY4
+        carry4.io.S  := VecInit(luts.drop(idx * 4).take(4).map(_.io.O6)).asUInt
+        carry4.io.DI := VecInit(tPrimes.drop(idx * 4).take(4)).asUInt
+    }
+
+    // Connect sum outputs
+    io.out := VecInit(carries.map(_.io.O).reverse).asUInt(outW-1, 0)
+  }
+
+  /** Quaternary adder for Xilinx Versal FPGAs
+   * 
+   * @param outW in-/output bit width
+   * 
+   * Implements a quaternary adder using LUT6CY and LOOKAHEAD8 primitives.
+   * The adder takes four input operands of equal bit width and
+   * produces a single output sum of the same bit width.
+   * 
+   * Note, does not implement any form of carry-in.
+   */
+  class QuaternaryAdder(outW: Int) extends TerminalAdder(4, outW) {
+    // Helper functions to get LOOKAHEAD8 connections
+    def look8CYs(look8: LOOKAHEAD8) = Seq(
+      look8.io.CYA, look8.io.CYB, look8.io.CYC, look8.io.CYD,
+      look8.io.CYE, look8.io.CYF, look8.io.CYG, look8.io.CYH
+    )
+    def look8COs(look8: LOOKAHEAD8) = Seq(
+      look8.io.CYA, look8.io.COUTB, look8.io.CYC, look8.io.COUTD,
+      look8.io.CYE, look8.io.COUTF, look8.io.CYG, look8.io.COUTH
+    )
+    def look8Props(look8: LOOKAHEAD8) = Seq(
+      look8.io.PROPA, look8.io.PROPB, look8.io.PROPC, look8.io.PROPD,
+      look8.io.PROPE, look8.io.PROPF, look8.io.PROPG, look8.io.PROPH
+    )
+
+    // Generate top and bottom LOOKAHEAD8s
+    val nLook8 = (outW + 7) / 8
+    val topLook8   = Seq.fill(nLook8) { Module(new LOOKAHEAD8("TRUE", "TRUE", "TRUE", "TRUE")) }
+    val topL8CYs   = topLook8.flatMap { look8CYs(_) }
+    val topL8COs   = topLook8.flatMap { look8COs(_) }
+    val topL8Props = topLook8.flatMap { look8Props(_) }
+    topLook8.head.io.CIN := false.B
+    topLook8.sliding(2).foreach {
+      case Seq(prev, next) => next.io.CIN := prev.io.COUTH
+      case _ =>
+    }
+
+    val botLook8   = Seq.fill(nLook8) { Module(new LOOKAHEAD8("TRUE", "TRUE", "TRUE", "TRUE")) }
+    val botL8CYs   = botLook8.flatMap { look8CYs(_) }
+    val botL8COs   = botLook8.flatMap { look8COs(_) }
+    val botL8Props = botLook8.flatMap { look8Props(_) }
+    botLook8.head.io.CIN := false.B
+    botLook8.sliding(2).foreach {
+      case Seq(prev, next) => next.io.CIN := prev.io.COUTH
+      case _ =>
+    }
+
+    // ... default assignments to avoid unconnected wires
+    topL8CYs  .foreach(_ := false.B)
+    topL8Props.foreach(_ := false.B)
+
+    botL8CYs  .foreach(_ := false.B)
+    botL8Props.foreach(_ := false.B)
+
+    // Boolean functions for the LUTs
+    val topLutFO51 = (ins: Seq[Boolean]) => ins.take(5).reduce(_ ^ _)
+    val topLutFO52 = (ins: Seq[Boolean]) => {
+      val s = ins.take(3).reduce(_ ^ _)
+      (s && ins(3)) || (s && ins(4)) || (ins(3) && ins(4))
+    }
+
+    val botLutFO51 = (ins: Seq[Boolean]) => {
+      val c = (ins(0) && ins(1)) || (ins(0) && ins(2)) || (ins(1) && ins(2))
+      c ^ ins(3) ^ ins(4)
+    }
+    val botLutFO52 = (ins: Seq[Boolean]) => {
+      val c = (ins(0) && ins(1)) || (ins(0) && ins(2)) || (ins(1) && ins(2))
+      (c && ins(3)) || (c && ins(4)) || (ins(3) && ins(4))
+    }
+
+    // Generate LUT6CY elements and connect to LOOKAHEAD8s
+    val topLuts = Seq.fill(outW) { Module(new LUT6CY(genLUT6CYInitString(topLutFO51, topLutFO52))) }
+    val botLuts = Seq.fill(outW) { Module(new LUT6CY(genLUT6CYInitString(botLutFO51, botLutFO52))) }
+    (0 until outW).foreach { i =>
+      topL8Props(i) := topLuts(i).io.PROP
+      botL8Props(i) := botLuts(i).io.PROP
+
+      topL8CYs(i) := topLuts(i).io.O52
+      botL8CYs(i) := botLuts(i).io.O52
+
+      if (i > 0) { // carries only from bit 1 onwards
+        topLuts(i).io.I4 := topL8COs(i-1)
+        botLuts(i).io.I4 := botL8COs(i-1)
+      } else {
+        topLuts(i).io.I4 := false.B
+        botLuts(i).io.I4 := false.B
+      }
+    }
+    topLuts.tail.zip(botLuts).foreach { case (top, bot) => bot.io.I3 := top.io.O51 }
+    botLuts.last.io.I3 := topLuts.last.io.O52 // final top-bottom carry
+
+    // Connect data inputs
+    (0 until outW).foreach { i =>
+      topLuts(i).io.I0 := io.in(0)(i)
+      topLuts(i).io.I1 := io.in(1)(i)
+      topLuts(i).io.I2 := io.in(2)(i)
+      topLuts(i).io.I3 := io.in(3)(i)
+
+      botLuts(i).io.I0 := io.in(0)(i)
+      botLuts(i).io.I1 := io.in(1)(i)
+      botLuts(i).io.I2 := io.in(2)(i)
+    }
+
+    // Connect sum outputs
+    io.out := VecInit(botLuts.map(_.io.O51)).asUInt ## topLuts.head.io.O51
+  }
+}

--- a/src/main/scala/approx/multiplication/comptree/TerminalAdders.scala
+++ b/src/main/scala/approx/multiplication/comptree/TerminalAdders.scala
@@ -76,7 +76,7 @@ private[comptree] object TerminalAdders {
     }
 
     // Connect sum outputs
-    io.out := VecInit(carries.map(_.io.O).reverse).asUInt(outW-1, 0)
+    io.out := VecInit(carries.map(_.io.O)).asUInt(outW-1, 0)
   }
 
   /** Quaternary adder for Xilinx Versal FPGAs
@@ -90,26 +90,12 @@ private[comptree] object TerminalAdders {
    * Note, does not implement any form of carry-in.
    */
   class QuaternaryAdder(outW: Int) extends TerminalAdder(4, outW) {
-    // Helper functions to get LOOKAHEAD8 connections
-    def look8CYs(look8: LOOKAHEAD8) = Seq(
-      look8.io.CYA, look8.io.CYB, look8.io.CYC, look8.io.CYD,
-      look8.io.CYE, look8.io.CYF, look8.io.CYG, look8.io.CYH
-    )
-    def look8COs(look8: LOOKAHEAD8) = Seq(
-      look8.io.CYA, look8.io.COUTB, look8.io.CYC, look8.io.COUTD,
-      look8.io.CYE, look8.io.COUTF, look8.io.CYG, look8.io.COUTH
-    )
-    def look8Props(look8: LOOKAHEAD8) = Seq(
-      look8.io.PROPA, look8.io.PROPB, look8.io.PROPC, look8.io.PROPD,
-      look8.io.PROPE, look8.io.PROPF, look8.io.PROPG, look8.io.PROPH
-    )
-
     // Generate top and bottom LOOKAHEAD8s
     val nLook8 = (outW + 7) / 8
     val topLook8   = Seq.fill(nLook8) { Module(new LOOKAHEAD8("TRUE", "TRUE", "TRUE", "TRUE")) }
-    val topL8CYs   = topLook8.flatMap { look8CYs(_) }
-    val topL8COs   = topLook8.flatMap { look8COs(_) }
-    val topL8Props = topLook8.flatMap { look8Props(_) }
+    val topL8CYs   = topLook8.flatMap(_.allCYs)
+    val topL8COs   = topLook8.flatMap(_.allCOs)
+    val topL8Props = topLook8.flatMap(_.allProps)
     topLook8.head.io.CIN := false.B
     topLook8.sliding(2).foreach {
       case Seq(prev, next) => next.io.CIN := prev.io.COUTH
@@ -117,9 +103,9 @@ private[comptree] object TerminalAdders {
     }
 
     val botLook8   = Seq.fill(nLook8) { Module(new LOOKAHEAD8("TRUE", "TRUE", "TRUE", "TRUE")) }
-    val botL8CYs   = botLook8.flatMap { look8CYs(_) }
-    val botL8COs   = botLook8.flatMap { look8COs(_) }
-    val botL8Props = botLook8.flatMap { look8Props(_) }
+    val botL8CYs   = botLook8.flatMap(_.allCYs)
+    val botL8COs   = botLook8.flatMap(_.allCOs)
+    val botL8Props = botLook8.flatMap(_.allProps)
     botLook8.head.io.CIN := false.B
     botLook8.sliding(2).foreach {
       case Seq(prev, next) => next.io.CIN := prev.io.COUTH

--- a/src/main/scala/approx/util/Xilinx.scala
+++ b/src/main/scala/approx/util/Xilinx.scala
@@ -500,6 +500,15 @@ object Xilinx {
         val PROPG = Input(Bool())
         val PROPH = Input(Bool())
       })
+
+      /** Return a sequence of carry inputs */
+      def allCYs = Seq(io.CYA, io.CYB, io.CYC, io.CYD, io.CYE, io.CYF, io.CYG, io.CYH)
+
+      /** Return a sequence of carry outputs */
+      def allCOs = Seq(io.CYA, io.COUTB, io.CYC, io.COUTD, io.CYE, io.COUTF, io.CYG, io.COUTH)
+
+      /** Return a sequence of propagate inputs */
+      def allProps = Seq(io.PROPA, io.PROPB, io.PROPC, io.PROPD, io.PROPE, io.PROPF, io.PROPG, io.PROPH)
     }
 
     class DSP58(aInput: String = "DIRECT", aMultSel: String = "A", bInput: String = "DIRECT", 


### PR DESCRIPTION
This PR addresses most of the todos left in the source code from last year, including:
- adding variable-length counter support for all compressors
- adding composable adders for Versal compressors
- adding ternary and quaternary terminal adders for 7-Series and Versal compressors
- extending accumulators with different operand bit-widths and pipelining